### PR TITLE
fix: change fee calculus as order in graph is desc

### DIFF
--- a/backtest.mjs
+++ b/backtest.mjs
@@ -124,8 +124,7 @@ export const liquidityForStrategy = (price, low, high, tokens0, tokens1, decimal
 export const calcFees = (data, pool, priceToken, liquidity, unboundedLiquidity, investment, min, max) => {
 
   return data.map((d, i) => {
-
-    const fg = i - 1 < 0 ? [0, 0] : calcUnboundedFees(d.feeGrowthGlobal0X128, data[(i-1)].feeGrowthGlobal0X128, d.feeGrowthGlobal1X128, data[(i-1)].feeGrowthGlobal1X128, pool);
+    const fg = i == 0 ? [0, 0] : calcUnboundedFees(data[i-1].feeGrowthGlobal0X128, d.feeGrowthGlobal0X128, data[i-1].feeGrowthGlobal1X128, d.feeGrowthGlobal1X128, pool);
 
     const low = priceToken === 0 ? d.low : 1 / (d.low === '0' ? 1 : d.low);
     const high = priceToken === 0 ? d.high : 1 / (d.high === '0' ? 1 : d.high);

--- a/backtest.mjs
+++ b/backtest.mjs
@@ -126,7 +126,6 @@ export const calcFees = (data, pool, priceToken, liquidity, unboundedLiquidity, 
   return data.map((d, i) => {
 
     const fg = i - 1 < 0 ? [0, 0] : calcUnboundedFees(d.feeGrowthGlobal0X128, data[(i-1)].feeGrowthGlobal0X128, d.feeGrowthGlobal1X128, data[(i-1)].feeGrowthGlobal1X128, pool);
-  //  const fg = i == 0 ? [0, 0] : calcUnboundedFees(data[i-1].feeGrowthGlobal0X128, d.feeGrowthGlobal0X128, data[i-1].feeGrowthGlobal1X128, d.feeGrowthGlobal1X128, pool);
     const low = priceToken === 0 ? d.low : 1 / (d.low === '0' ? 1 : d.low);
     const high = priceToken === 0 ? d.high : 1 / (d.high === '0' ? 1 : d.high);
 

--- a/backtest.mjs
+++ b/backtest.mjs
@@ -126,7 +126,7 @@ export const calcFees = (data, pool, priceToken, liquidity, unboundedLiquidity, 
   return data.map((d, i) => {
 
     const fg = i - 1 < 0 ? [0, 0] : calcUnboundedFees(d.feeGrowthGlobal0X128, data[(i-1)].feeGrowthGlobal0X128, d.feeGrowthGlobal1X128, data[(i-1)].feeGrowthGlobal1X128, pool);
-
+  //  const fg = i == 0 ? [0, 0] : calcUnboundedFees(data[i-1].feeGrowthGlobal0X128, d.feeGrowthGlobal0X128, data[i-1].feeGrowthGlobal1X128, d.feeGrowthGlobal1X128, pool);
     const low = priceToken === 0 ? d.low : 1 / (d.low === '0' ? 1 : d.low);
     const high = priceToken === 0 ? d.high : 1 / (d.high === '0' ? 1 : d.high);
 
@@ -169,11 +169,10 @@ export const calcFees = (data, pool, priceToken, liquidity, unboundedLiquidity, 
     }
 
     const date = new Date(d.periodStartUnix*1000);
-
     return {
       ...d,
-      day: date.getDate(),
-      month: date.getMonth(),
+      day: date.getUTCDate(),
+      month: date.getUTCMonth(),
       year: date.getFullYear(), 
       fg0 : fg[0],
       fg1 : fg[1],
@@ -253,6 +252,5 @@ export const pivotFeeData = (data, priceToken, investment) => {
       }
     }
   });
-
   return pivot;
 }

--- a/index.js
+++ b/index.js
@@ -18,15 +18,15 @@ export const uniswapStrategyBacktest = async ( pool, investmentAmount, minRange,
     const hourlyPriceData = await getPoolHourData(pool, DateByDaysAgo(opt.days), opt.protocol);
     
     if (poolData && hourlyPriceData && hourlyPriceData.length > 0) {
-      const entryPrice = opt.priceToken === 0 ? hourlyPriceData[0].close : 1 / hourlyPriceData[0].close;
+
+      const backtestData = hourlyPriceData.reverse();
+      const entryPrice = opt.priceToken === 1 ?  1 / backtestData[0].close : backtestData[0].close
       const tokens = tokensForStrategy(minRange, maxRange, investmentAmount, entryPrice, poolData.token1.decimals - poolData.token0.decimals);
       const liquidity = liquidityForStrategy(entryPrice, minRange, maxRange, tokens[0], tokens[1], poolData.token0.decimals, poolData.token1.decimals);
       const unbLiquidity = liquidityForStrategy(entryPrice, Math.pow(1.0001, -887220), Math.pow(1.0001, 887220), tokens[0], tokens[1], poolData.token0.decimals, poolData.token1.decimals);
-
-      const hourlyBacktest = calcFees(hourlyPriceData, poolData, opt.priceToken, liquidity, unbLiquidity, investmentAmount, minRange, maxRange);
+      const hourlyBacktest = calcFees(backtestData, poolData, opt.priceToken, liquidity, unbLiquidity, investmentAmount, minRange, maxRange);
       return opt.period === 'daily' ? pivotFeeData(hourlyBacktest, opt.priceToken, investmentAmount) : hourlyBacktest;
     }
-
   }
 }
 


### PR DESCRIPTION
As data coming from the graph is coming in descending order fee diff from current period to previous one would be negative.
While keeping order the same we can still calculate unbounded fees by changing the order in equation