### PR TITLE
feat: add ranges for estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,36 @@ npm install uniswap-v3-backtest
 ## Usage 
 
 ```js
+// get results for last 25 days
 import uniswapStrategyBacktest from 'uniswap-v3-backtest'
 const backtestResults = await uniswapStrategyBacktest("0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", 1000, 2120.09, 2662.99, {days: 25, period: "daily"});
+
+// get results from start timestamp for lp from quote token 
+await uniswapStrategyBacktest(
+  "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", 
+  1,
+  1/2662.99,
+  1/2120.09,
+  {startTimestamp: 1653364800, period: "daily", priceToken: 1}
+);
+
+// get results from start timestamp to end timestamp for lp from quote token 
+await uniswapStrategyBacktest(
+  "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", 
+  1,
+  1/2662.99,
+  1/2120.09,
+  {startTimestamp: 1653364800, endTimestamp: 1653374800, period: "daily", priceToken: 1}
+);
+
+// get results for n days before end timestamp for lp from quote token 
+await uniswapStrategyBacktest(
+  "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", 
+  1,
+  1/2662.99,
+  1/2120.09,
+  {endTimestamp: 1653364800, days: 1, period: "daily", priceToken: 1}
+);
 ```
 
 Example Output: 
@@ -108,6 +136,8 @@ uniswapStrategyBacktest(
 
 **options** = Optional values that override default values. Formed as a JSON key value pair `{days: 30, protocol: 0, priceToken: 0, period: "hourly"}`    
         **days** = number of days to run the backtest from todays date. Defaults to 30, Currently maxed to 30.     
+        **startTimestamp** = timestamp in seconds for LP start. Optional.     
+        **endTimestamp** = timestamp in seconds for LP end. Optional. If used with *days* provides results for `n` days before timestamp  
         **priceToken** = 0 = values in baseToken, 1 = values in quoteToken (Token0, Token1) 
         **period** = Calculate fees "daily" or "hourly", defaults to "hourly"  
         **protocol** - Which chain, sidechain or L2 to use:  

--- a/uniPoolData.mjs
+++ b/uniPoolData.mjs
@@ -28,10 +28,10 @@ const requestBody = (request) => {
 
 }
 
-export const getPoolHourData = async (pool, fromdate, protocol) => {
+export const getPoolHourData = async (pool, fromdate, todate, protocol) => {
 
-  const query =  `query PoolHourDatas($pool: ID!, $fromdate: Int!) {
-  poolHourDatas ( where:{ pool:$pool, periodStartUnix_gt:$fromdate close_gt: 0}, orderBy:periodStartUnix, orderDirection:desc, first:1000) {
+  const query =  `query PoolHourDatas($pool: ID!, $fromdate: Int!, $todate: Int!) {
+  poolHourDatas ( where:{ pool:$pool, periodStartUnix_gt:$fromdate periodStartUnix_lt:$todate close_gt: 0}, orderBy:periodStartUnix, orderDirection:desc, first:1000) {
     periodStartUnix
     liquidity
     high
@@ -56,7 +56,7 @@ export const getPoolHourData = async (pool, fromdate, protocol) => {
   const url = urlForProtocol(protocol);
 
   try {
-    const response = await fetch(url, requestBody({query: query, variables: {pool: pool, fromdate: fromdate} }));
+    const response = await fetch(url, requestBody({query: query, variables: {pool: pool, fromdate: fromdate, todate} }));
     const data = await response.json();
 
     if (data && data.data && data.data.poolHourDatas) {


### PR DESCRIPTION
Added logic to specify timestamps for ranges to run estimation within.
Still limited to 41.66(6) days due to the graph 1000 query limit without pagination.